### PR TITLE
Arreglado el error mortal de necesidad

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
     </style>
 


### PR DESCRIPTION
El tema no era compatible con el SDK que usas, ahora el tema base de tu AppTheme es Themes.AppCompat.Light.DarkActionBar para que mantenga el color oscuro, pero me parece horrible la elección de los colores.